### PR TITLE
202 print improvements

### DIFF
--- a/src-test/unit_tests.cpp
+++ b/src-test/unit_tests.cpp
@@ -36,6 +36,7 @@
 #include <signal.h>
 #include <string.h>
 #include <time.h>
+#include <tuple>
 
 #ifndef _WIN32
 #include <wait.h>
@@ -2339,6 +2340,21 @@ TEST(PrintTests, PrintUint64Max) {
     free((void*)value);
 }
 
+TEST(PrintTests, PrintUintZero) {
+    const char json[] = R"([0])";
+    const QAJ4C_Value* value = QAJ4C_parse_opt_dynamic(json, ARRAY_COUNT(json), 0, realloc);
+
+    assert(!QAJ4C_is_error(value));
+
+    char output[ARRAY_COUNT(json)];
+    size_t out = QAJ4C_sprint(value, output, ARRAY_COUNT(output));
+    assert(ARRAY_COUNT(output) == out);
+    assert(strcmp(json, output) == 0);
+
+    free((void*)value);
+}
+
+
 TEST(PrintTests, PrintStringWithNewLine) {
     char json[] = R"(["Hello\nWorld"])";
     const QAJ4C_Value* value = QAJ4C_parse_opt_dynamic(json, ARRAY_COUNT(json), 0, realloc);
@@ -2398,6 +2414,65 @@ TEST(PrintTests, PrintDoubleDomInfinity) {
     assert(strcmp("null", output) == 0);
 }
 
+/**
+ * This callback method simply compares each individual character and returns true on a match
+ * and false on a miss.
+ */
+static bool simple_print_callback_impl( void *ptr, char c ) {
+    std::pair<size_t, const char*>& data = *reinterpret_cast<std::pair<size_t, const char*>*>(ptr);
+    bool result = data.second[data.first] == c;
+    data.first += 1;
+    return result;
+}
+
+TEST(PrintTests, PrintWithCallback) {
+    const char* msg = "Hello";
+    std::pair<size_t, const char*> expected_data{0, "\"Hello\""};
+    QAJ4C_Value value;
+    QAJ4C_set_string_ref(&value, msg);
+
+    bool result = QAJ4C_print_callback(&value, simple_print_callback_impl, &expected_data );
+    assert(result);
+}
+
+TEST(PrintTests, PrintWithCallbackNullsafe) {
+    const char* msg = "Hello";
+    QAJ4C_Value value;
+    QAJ4C_set_string_ref(&value, msg);
+
+    assert(!QAJ4C_print_callback(&value, NULL, NULL ));
+}
+
+/**
+ * For simplicity the simple_print_callback_impl implementation will be used to check the
+ * message char by char.
+ */
+static bool buffer_print_callback_impl( void* ptr, const char* buffer, size_t buffer_length ) {
+    bool result = true;
+    for (size_t i = 0; i < buffer_length; ++i) {
+        result = result && simple_print_callback_impl(ptr, buffer[i]);
+    }
+    return result;
+}
+
+
+TEST(PrintTests, PrintBufferWithCallback) {
+    const char* msg = "Hello";
+    std::pair<size_t, const char*> expected_data{0, "\"Hello\""};
+    QAJ4C_Value value;
+    QAJ4C_set_string_ref(&value, msg);
+
+    bool result = QAJ4C_print_buffer_callback(&value, buffer_print_callback_impl, &expected_data );
+    assert(result);
+}
+
+TEST(PrintTests, PrintBufferWithCallbackNullsafe) {
+    const char* msg = "Hello";
+    QAJ4C_Value value;
+    QAJ4C_set_string_ref(&value, msg);
+
+    assert(!QAJ4C_print_buffer_callback(&value, NULL, NULL ));
+}
 
 /**
  * Parse the same message twice and compare the results with each other.
@@ -2883,7 +2958,27 @@ TEST(ObjectBuilderTests, SimpleObjectWithIntegers) {
 }
 
 /**
- * in this test the
+ * Same as the basic test ... but now by creating members by copy.
+ */
+TEST(ObjectBuilderTests, SimpleObjectWithIntegersKeysAsCopy) {
+    uint8_t buff[256];
+    QAJ4C_Builder builder;
+    QAJ4C_builder_init(&builder, buff, ARRAY_COUNT(buff));
+    QAJ4C_Value* value_ptr = QAJ4C_builder_get_document(&builder);
+
+    QAJ4C_Object_builder obj_builder = QAJ4C_object_builder_init(value_ptr, 2, false, &builder);
+
+    QAJ4C_set_uint(QAJ4C_object_builder_create_member_by_copy(&obj_builder, "id", &builder), 32);
+    QAJ4C_set_uint(QAJ4C_object_builder_create_member_by_copy(&obj_builder, "value", &builder), 99);
+
+    char out[64];
+    QAJ4C_sprint(value_ptr, out, ARRAY_COUNT(out));
+    assert(strcmp(R"({"id":32,"value":99})", out) == 0);
+}
+
+/**
+ * In this test the object builder is created for more fields than actually used.
+ * It is expected that the unused fields will not be printed.
  */
 TEST(ObjectBuilderTests, SimpleObjectWithIntegersAndUnusedFields) {
     uint8_t buff[256];

--- a/src-test/unit_tests.cpp
+++ b/src-test/unit_tests.cpp
@@ -2958,25 +2958,6 @@ TEST(ObjectBuilderTests, SimpleObjectWithIntegers) {
 }
 
 /**
- * Same as the basic test ... but now by creating members by copy.
- */
-TEST(ObjectBuilderTests, SimpleObjectWithIntegersKeysAsCopy) {
-    uint8_t buff[256];
-    QAJ4C_Builder builder;
-    QAJ4C_builder_init(&builder, buff, ARRAY_COUNT(buff));
-    QAJ4C_Value* value_ptr = QAJ4C_builder_get_document(&builder);
-
-    QAJ4C_Object_builder obj_builder = QAJ4C_object_builder_init(value_ptr, 2, false, &builder);
-
-    QAJ4C_set_uint(QAJ4C_object_builder_create_member_by_copy(&obj_builder, "id", &builder), 32);
-    QAJ4C_set_uint(QAJ4C_object_builder_create_member_by_copy(&obj_builder, "value", &builder), 99);
-
-    char out[64];
-    QAJ4C_sprint(value_ptr, out, ARRAY_COUNT(out));
-    assert(strcmp(R"({"id":32,"value":99})", out) == 0);
-}
-
-/**
  * In this test the object builder is created for more fields than actually used.
  * It is expected that the unused fields will not be printed.
  */
@@ -3034,6 +3015,88 @@ TEST(ObjectBuilderTests, SimpleObjectWithIntegersNoDeduplication) {
     QAJ4C_set_uint(QAJ4C_object_builder_create_member_by_ref(&obj_builder, "id"), 32);
     QAJ4C_set_uint(QAJ4C_object_builder_create_member_by_ref(&obj_builder, "value"), 99);
     QAJ4C_set_uint(QAJ4C_object_builder_create_member_by_ref(&obj_builder, "id"), 1);
+
+    char out[64];
+    QAJ4C_sprint(value_ptr, out, ARRAY_COUNT(out));
+    assert(QAJ4C_object_size(value_ptr) == 3);
+    assert(strcmp(R"({"id":32,"value":99,"id":1})", out) == 0);
+}
+
+/**
+ * Same test as SimpleObjectWithIntegers ... but now by creating members by copy.
+ */
+TEST(ObjectBuilderTests, SimpleObjectWithIntegersKeysAsCopy) {
+    uint8_t buff[256];
+    QAJ4C_Builder builder;
+    QAJ4C_builder_init(&builder, buff, ARRAY_COUNT(buff));
+    QAJ4C_Value* value_ptr = QAJ4C_builder_get_document(&builder);
+
+    QAJ4C_Object_builder obj_builder = QAJ4C_object_builder_init(value_ptr, 2, false, &builder);
+
+    QAJ4C_set_uint(QAJ4C_object_builder_create_member_by_copy(&obj_builder, "id", &builder), 32);
+    QAJ4C_set_uint(QAJ4C_object_builder_create_member_by_copy(&obj_builder, "value", &builder), 99);
+
+    char out[64];
+    QAJ4C_sprint(value_ptr, out, ARRAY_COUNT(out));
+    assert(strcmp(R"({"id":32,"value":99})", out) == 0);
+}
+
+/**
+ * Same test as SimpleObjectWithIntegersAndUnusedFields ... but now by creating members by copy.
+ */
+TEST(ObjectBuilderTests, SimpleObjectWithIntegersAndUnusedFieldsKeysAsCopy) {
+    uint8_t buff[256];
+    QAJ4C_Builder builder;
+    QAJ4C_builder_init(&builder, buff, ARRAY_COUNT(buff));
+    QAJ4C_Value* value_ptr = QAJ4C_builder_get_document(&builder);
+
+    QAJ4C_Object_builder obj_builder = QAJ4C_object_builder_init(value_ptr, 4, false, &builder);
+
+    QAJ4C_set_uint(QAJ4C_object_builder_create_member_by_copy(&obj_builder, "id", &builder), 32);
+    QAJ4C_set_uint(QAJ4C_object_builder_create_member_by_copy(&obj_builder, "value", &builder), 99);
+
+    char out[64];
+    QAJ4C_sprint(value_ptr, out, ARRAY_COUNT(out));
+    assert(QAJ4C_object_size(value_ptr) == 2);
+    assert(strcmp(R"({"id":32,"value":99})", out) == 0);
+}
+
+
+/**
+ * Same test as SimpleObjectWithIntegersDeduplication ... but now by creating members by copy.
+ */
+TEST(ObjectBuilderTests, SimpleObjectWithIntegersDeduplicationKeysAsCopy) {
+    uint8_t buff[256];
+    QAJ4C_Builder builder;
+    QAJ4C_builder_init(&builder, buff, ARRAY_COUNT(buff));
+    QAJ4C_Value* value_ptr = QAJ4C_builder_get_document(&builder);
+
+    QAJ4C_Object_builder obj_builder = QAJ4C_object_builder_init(value_ptr, 4, true, &builder);
+
+    QAJ4C_set_uint(QAJ4C_object_builder_create_member_by_copy(&obj_builder, "id", &builder), 32);
+    QAJ4C_set_uint(QAJ4C_object_builder_create_member_by_copy(&obj_builder, "value", &builder), 99);
+    QAJ4C_set_uint(QAJ4C_object_builder_create_member_by_copy(&obj_builder, "id", &builder), 1);
+
+    char out[64];
+    QAJ4C_sprint(value_ptr, out, ARRAY_COUNT(out));
+    assert(QAJ4C_object_size(value_ptr) == 2);
+    assert(strcmp(R"({"id":1,"value":99})", out) == 0);
+}
+
+/**
+ * Same test as SimpleObjectWithIntegersNoDeduplication ... but now by creating members by copy.
+ */
+TEST(ObjectBuilderTests, SimpleObjectWithIntegersNoDeduplicationKeysAsCopy) {
+    uint8_t buff[256];
+    QAJ4C_Builder builder;
+    QAJ4C_builder_init(&builder, buff, ARRAY_COUNT(buff));
+    QAJ4C_Value* value_ptr = QAJ4C_builder_get_document(&builder);
+
+    QAJ4C_Object_builder obj_builder = QAJ4C_object_builder_init(value_ptr, 4, false, &builder);
+
+    QAJ4C_set_uint(QAJ4C_object_builder_create_member_by_copy(&obj_builder, "id", &builder), 32);
+    QAJ4C_set_uint(QAJ4C_object_builder_create_member_by_copy(&obj_builder, "value", &builder), 99);
+    QAJ4C_set_uint(QAJ4C_object_builder_create_member_by_copy(&obj_builder, "id", &builder), 1);
 
     char out[64];
     QAJ4C_sprint(value_ptr, out, ARRAY_COUNT(out));

--- a/src/qajson4c/qajson4c.c
+++ b/src/qajson4c/qajson4c.c
@@ -496,11 +496,6 @@ QAJ4C_Value* QAJ4C_object_create_member_by_copy( QAJ4C_Value* value_ptr, const c
     return QAJ4C_object_create_member_by_copy_n(value_ptr, str, QAJ4C_STRLEN(str), builder);
 }
 
-QAJ4C_Member* QAJ4C_object_get_member_rw( QAJ4C_Value* value_ptr, size_t index ) {
-    QAJ4C_ASSERT(QAJ4C_is_object(value_ptr), {return NULL;});
-    return &((QAJ4C_Object*)value_ptr)->top[index];
-}
-
 void QAJ4C_object_optimize( QAJ4C_Value* value_ptr ) {
     QAJ4C_ASSERT(QAJ4C_is_object(value_ptr), {return;});
 

--- a/src/qajson4c/qajson4c.c
+++ b/src/qajson4c/qajson4c.c
@@ -125,7 +125,7 @@ bool QAJ4C_print_buffer_callback( const QAJ4C_Value* value_ptr, QAJ4C_print_buff
     return QAJ4C_print_buffer_callback_impl(value_ptr, callback, ptr);
 }
 
-bool QAJ4C_is_string(const QAJ4C_Value* value_ptr) {
+bool QAJ4C_is_string( const QAJ4C_Value* value_ptr ) {
     return QAJ4C_get_type(value_ptr) == QAJ4C_TYPE_STRING;
 }
 
@@ -168,7 +168,7 @@ bool QAJ4C_string_equals( const QAJ4C_Value* value_ptr, const char* str )
     return QAJ4C_string_equals_n(value_ptr, str, QAJ4C_STRLEN(str));
 }
 
-bool QAJ4C_is_object(const QAJ4C_Value* value_ptr) {
+bool QAJ4C_is_object( const QAJ4C_Value* value_ptr ) {
     return QAJ4C_get_type(value_ptr) == QAJ4C_TYPE_OBJECT;
 }
 
@@ -176,7 +176,7 @@ bool QAJ4C_is_array( const QAJ4C_Value* value_ptr ){
     return QAJ4C_get_type(value_ptr) == QAJ4C_TYPE_ARRAY;
 }
 
-bool QAJ4C_is_int(const QAJ4C_Value* value_ptr) {
+bool QAJ4C_is_int( const QAJ4C_Value* value_ptr ) {
     return QAJ4C_get_type(value_ptr) == QAJ4C_TYPE_NUMBER && (QAJ4C_get_compatibility_types(value_ptr) & QAJ4C_PRIMITIVE_INT) != 0;
 }
 
@@ -241,7 +241,7 @@ bool QAJ4C_get_bool( const QAJ4C_Value* value_ptr ) {
     return ((QAJ4C_Primitive*) value_ptr)->data.b;
 }
 
-bool QAJ4C_is_not_set(const QAJ4C_Value* value_ptr) {
+bool QAJ4C_is_not_set( const QAJ4C_Value* value_ptr ) {
     return value_ptr == NULL;
 }
 
@@ -260,17 +260,17 @@ bool QAJ4C_is_error( const QAJ4C_Value* value_ptr ) {
     return QAJ4C_get_internal_type(value_ptr) == QAJ4C_ERROR_DESCRIPTION;
 }
 
-const char* QAJ4C_error_get_json(const QAJ4C_Value* value_ptr) {
+const char* QAJ4C_error_get_json( const QAJ4C_Value* value_ptr ) {
     QAJ4C_ASSERT(QAJ4C_is_error(value_ptr), {return "";});
     return ((QAJ4C_Error*) value_ptr)->info->json;
 }
 
-QAJ4C_ERROR_CODE QAJ4C_error_get_errno(const QAJ4C_Value* value_ptr) {
+QAJ4C_ERROR_CODE QAJ4C_error_get_errno( const QAJ4C_Value* value_ptr ) {
     QAJ4C_ASSERT(QAJ4C_is_error(value_ptr), {return 0;});
     return ((QAJ4C_Error*) value_ptr)->info->err_no;
 }
 
-size_t QAJ4C_error_get_json_pos(const QAJ4C_Value* value_ptr) {
+size_t QAJ4C_error_get_json_pos( const QAJ4C_Value* value_ptr ) {
     QAJ4C_ASSERT(QAJ4C_is_error(value_ptr), {return 0;});
     return ((QAJ4C_Error*) value_ptr)->info->json_pos;
 }
@@ -285,17 +285,17 @@ const QAJ4C_Member* QAJ4C_object_get_member( const QAJ4C_Value* value_ptr, size_
     return &((QAJ4C_Object*) value_ptr)->top[index];
 }
 
-const QAJ4C_Value* QAJ4C_member_get_key(const QAJ4C_Member* member) {
+const QAJ4C_Value* QAJ4C_member_get_key( const QAJ4C_Member* member ) {
     QAJ4C_ASSERT(member != NULL, {return NULL;});
     return &member->key;
 }
 
-const QAJ4C_Value* QAJ4C_member_get_value(const QAJ4C_Member* member) {
+const QAJ4C_Value* QAJ4C_member_get_value( const QAJ4C_Member* member ) {
     QAJ4C_ASSERT(member != NULL, {return NULL;});
     return &member->value;
 }
 
-const QAJ4C_Value* QAJ4C_object_get_n(const QAJ4C_Value* value_ptr, const char* str, size_t len) {
+const QAJ4C_Value* QAJ4C_object_get_n( const QAJ4C_Value* value_ptr, const char* str, size_t len ) {
     QAJ4C_Value wrapper_value;
     QAJ4C_ASSERT(QAJ4C_is_object(value_ptr), {return NULL;});
 

--- a/src/qajson4c/qajson4c.c
+++ b/src/qajson4c/qajson4c.c
@@ -541,7 +541,7 @@ QAJ4C_Value* QAJ4C_object_builder_create_member_by_ref_n( QAJ4C_Object_builder* 
 
 QAJ4C_Value* QAJ4C_object_builder_create_member_by_ref( QAJ4C_Object_builder* value_ptr, const char* str )
 {
-    return QAJ4C_object_builder_create_member_by_ref_n( value_ptr, str, QAJ4C_STRLEN( str ) );
+    return QAJ4C_object_builder_create_member_by_ref_n(value_ptr, str, QAJ4C_STRLEN(str));
 }
 
 QAJ4C_Value* QAJ4C_object_builder_create_member_by_copy_n( QAJ4C_Object_builder* value_ptr, const char* str, size_t len, QAJ4C_Builder* builder )
@@ -559,9 +559,7 @@ QAJ4C_Value* QAJ4C_object_builder_create_member_by_copy_n( QAJ4C_Object_builder*
         QAJ4C_Member* member = &object_ptr->top[value_ptr->pos];
         QAJ4C_set_string_copy_n(&member->key, str, len, builder);
         return_value = &member->value;
-    }
 
-    if (return_value != NULL) {
         value_ptr->pos += 1;
         object_ptr->count = value_ptr->pos;
     }
@@ -571,7 +569,7 @@ QAJ4C_Value* QAJ4C_object_builder_create_member_by_copy_n( QAJ4C_Object_builder*
 
 QAJ4C_Value* QAJ4C_object_builder_create_member_by_copy( QAJ4C_Object_builder* value_ptr, const char* str, QAJ4C_Builder* builder )
 {
-    return QAJ4C_object_builder_create_member_by_copy_n( value_ptr, str, QAJ4C_STRLEN( str ), builder );
+    return QAJ4C_object_builder_create_member_by_copy_n(value_ptr, str, QAJ4C_STRLEN(str), builder);
 }
 
 void QAJ4C_copy( const QAJ4C_Value* src, QAJ4C_Value* dest, QAJ4C_Builder* builder ) {

--- a/src/qajson4c/qajson4c.h
+++ b/src/qajson4c/qajson4c.h
@@ -422,7 +422,7 @@ bool QAJ4C_get_bool( const QAJ4C_Value* value_ptr );
  * This method will return true, in case the value pointer is not set (thus the NULL-pointer).
  * @note This method is NULL-safe!
  */
-bool QAJ4C_is_not_set( const QAJ4C_Value* value_ptr);
+bool QAJ4C_is_not_set( const QAJ4C_Value* value_ptr );
 
 /**
  * This method will return true, in case the value pointer is null

--- a/src/qajson4c/qajson4c.h
+++ b/src/qajson4c/qajson4c.h
@@ -65,6 +65,14 @@ struct QAJ4C_Builder {
 };
 typedef struct QAJ4C_Builder QAJ4C_Builder;
 
+struct QAJ4C_Object_builder {
+    QAJ4C_Value* object;
+    bool strict;
+    size_t pos;
+    size_t count;
+};
+typedef struct QAJ4C_Object_builder QAJ4C_Object_builder;
+
 /**
  * This method will get called in case of a fatal error
  * (array access on not array QAJ4C_Value).
@@ -78,10 +86,17 @@ typedef void (*QAJ4C_fatal_error_fn)( void );
 typedef void* (*QAJ4C_realloc_fn)( void *ptr, size_t size );
 
 /**
- * This type defines a callback method for the print method.
+ * This type defines a callback method for the print method. This callback will be called
+ * for each individual char.
  * @return true, on success else false.
  */
 typedef bool (*QAJ4C_print_callback_fn)( void *ptr, char c );
+
+/**
+ * Second print callback type that will be called with a buffer and size.
+ * @return true, on success else false.
+ */
+typedef bool (*QAJ4C_print_buffer_callback_fn)( void *ptr, const char* buffer, size_t size );
 
 /**
  * Error codes that can be expected from the qa json parser.
@@ -241,6 +256,12 @@ size_t QAJ4C_sprint( const QAJ4C_Value* value_ptr, char* buffer, size_t buffer_s
  * supplied to be handed over to the callback.
  */
 bool QAJ4C_print_callback( const QAJ4C_Value* value_ptr, QAJ4C_print_callback_fn callback, void* ptr );
+
+/**
+ * This method prints the DOM as JSON using the provided callback. Also a data ptr can be
+ * supplied to be handed over to the callback.
+ */
+bool QAJ4C_print_buffer_callback( const QAJ4C_Value* value_ptr, QAJ4C_print_buffer_callback_fn callback, void* ptr );
 
 /**
  * This method will return true, in case the value can be read out as string.
@@ -624,7 +645,7 @@ QAJ4C_Value* QAJ4C_object_create_member_by_ref_n( QAJ4C_Value* value_ptr, const 
  * This way the string does not have to be copied over to the buffer, but the string has to stay
  * valid until the DOM is not required anymore.
  *
- * @note This is a shortcut version of the QAJ4C_object_create_member_by_ref2 method, using
+ * @note This is a shortcut version of the QAJ4C_object_create_member_by_ref_n method, using
  * strlen to calculate the string length.
  */
 QAJ4C_Value* QAJ4C_object_create_member_by_ref( QAJ4C_Value* value_ptr, const char* str );
@@ -639,10 +660,54 @@ QAJ4C_Value* QAJ4C_object_create_member_by_copy_n( QAJ4C_Value* value_ptr, const
  * This method creates a member within the object doing a copy of the handed over string.
  * The allocation will be performed on the handed over builder.
  *
- * @note This is a shortcut version of the QAJ4C_object_create_member_by_copy2 method, using
+ * @note This is a shortcut version of the QAJ4C_object_create_member_by_copy_n method, using
  * strlen to calculate the string length.
  */
 QAJ4C_Value* QAJ4C_object_create_member_by_copy( QAJ4C_Value* value_ptr, const char* str, QAJ4C_Builder* builder );
+
+/**
+ * This method creates a QAJ4C_Object_builder to fill the data of an QAJ4C_Object with a given size.
+ *
+ * @param value_ptr the value pointer to allocate the object.
+ * @param member_count the amount of members
+ * @param deduplicate, if set to true, the builder will ensure that no duplicate key strings are used
+ *                     and will then return the already present value so the application can overwrite it.
+ *                     If sest to false, new members are appended without lookup overhead.
+ * @return the builder instance.
+ */
+QAJ4C_Object_builder QAJ4C_object_builder_init( QAJ4C_Value* value_ptr, size_t member_count, bool deduplicate, QAJ4C_Builder* builder );
+
+/**
+ * This method creates a member within the object using the reference of the handed over string.
+ * This way the string does not have to be copied over to the buffer, but the string has to stay
+ * valid until the DOM is not required anymore.
+ */
+QAJ4C_Value* QAJ4C_object_builder_create_member_by_ref_n( QAJ4C_Object_builder* value_ptr, const char* str, size_t len );
+
+/**
+ * This method creates a member within the object using the reference of the handed over string.
+ * This way the string does not have to be copied over to the buffer, but the string has to stay
+ * valid until the DOM is not required anymore.
+ *
+ * @note This is a shortcut version of the QAJ4C_object_create_member_by_ref_n method, using
+ * strlen to calculate the string length.
+ */
+QAJ4C_Value* QAJ4C_object_builder_create_member_by_ref( QAJ4C_Object_builder* value_ptr, const char* str );
+
+/**
+ * This method creates a member within the object doing a copy of the handed over string.
+ * The allocation will be performed on the handed over builder.
+ */
+QAJ4C_Value* QAJ4C_object_builder_create_member_by_copy_n( QAJ4C_Object_builder* value_ptr, const char* str, size_t len, QAJ4C_Builder* builder );
+
+/**
+ * This method creates a member within the object doing a copy of the handed over string.
+ * The allocation will be performed on the handed over builder.
+ *
+ * @note This is a shortcut version of the QAJ4C_object_create_member_by_copy_n method, using
+ * strlen to calculate the string length.
+ */
+QAJ4C_Value* QAJ4C_object_builder_create_member_by_copy( QAJ4C_Object_builder* value_ptr, const char* str, QAJ4C_Builder* builder );
 
 /**
  * This method creates a deep copy of the source value to the destination value using the

--- a/src/qajson4c/qajson4c.h
+++ b/src/qajson4c/qajson4c.h
@@ -672,7 +672,7 @@ QAJ4C_Value* QAJ4C_object_create_member_by_copy( QAJ4C_Value* value_ptr, const c
  * @param member_count the amount of members
  * @param deduplicate, if set to true, the builder will ensure that no duplicate key strings are used
  *                     and will then return the already present value so the application can overwrite it.
- *                     If sest to false, new members are appended without lookup overhead.
+ *                     If set to false, new members are appended without lookup overhead.
  * @return the builder instance.
  */
 QAJ4C_Object_builder QAJ4C_object_builder_init( QAJ4C_Value* value_ptr, size_t member_count, bool deduplicate, QAJ4C_Builder* builder );

--- a/src/qajson4c/qajson4c_internal.c
+++ b/src/qajson4c/qajson4c_internal.c
@@ -137,9 +137,12 @@ bool QAJ4C_print_callback_string( const char *string, QAJ4C_print_buffer_callbac
 static const char QAJ4C_NULL_STR[] = "null";
 static const char QAJ4C_TRUE_STR[] = "true";
 static const char QAJ4C_FALSE_STR[] = "false";
-static const unsigned QAJ4C_NULL_STR_LEN = sizeof(QAJ4C_NULL_STR) / sizeof(QAJ4C_NULL_STR[0]) - 1;
-static const unsigned QAJ4C_TRUE_STR_LEN = sizeof(QAJ4C_TRUE_STR) / sizeof(QAJ4C_TRUE_STR[0]) - 1;
-static const unsigned QAJ4C_FALSE_STR_LEN = sizeof(QAJ4C_FALSE_STR) / sizeof(QAJ4C_FALSE_STR[0]) - 1;
+
+#define ARRAY_COUNT(a) (sizeof(a) / sizeof(a[0]) - 1)
+
+static const unsigned QAJ4C_NULL_STR_LEN = ARRAY_COUNT(QAJ4C_NULL_STR);
+static const unsigned QAJ4C_TRUE_STR_LEN = ARRAY_COUNT(QAJ4C_TRUE_STR);
+static const unsigned QAJ4C_FALSE_STR_LEN = ARRAY_COUNT(QAJ4C_FALSE_STR);
 
 static int QAJ4C_xdigit( char c ) {
     return (c > '9')? (c &~ 0x20) - 'A' + 10: (c - '0');
@@ -1138,7 +1141,7 @@ int QAJ4C_compare_members( const void* lhs, const void* rhs ) {
     return QAJ4C_is_null(&left->key) ? 1 : -1;
 }
 
-bool QAJ4C_print_buffer_callback_impl( const QAJ4C_Value* value_ptr, QAJ4C_print_buffer_callback_fn callback, void* ptr)
+bool QAJ4C_print_buffer_callback_impl( const QAJ4C_Value* value_ptr, QAJ4C_print_buffer_callback_fn callback, void* ptr )
 {
     bool result = false;
     switch (QAJ4C_get_internal_type(value_ptr)) {
@@ -1360,11 +1363,11 @@ bool QAJ4C_print_callback_string( const char *string, QAJ4C_print_buffer_callbac
 bool QAJ4C_print_callback_error( const QAJ4C_Error* value_ptr, QAJ4C_print_buffer_callback_fn callback, void *ptr )
 {
     static const char ERR_MSG[] = "{\"error\":\"Unable to parse json message. Error (";
-    static const size_t ERR_MSG_LEN = sizeof(ERR_MSG) / sizeof(ERR_MSG[0]) - 1;
+    static const size_t ERR_MSG_LEN = ARRAY_COUNT(ERR_MSG);
     static const char ERR_MSG_2[] = ") at position ";
-    static const size_t ERR_MSG_2_LEN = sizeof(ERR_MSG_2) / sizeof(ERR_MSG_2[0]) - 1;
+    static const size_t ERR_MSG_2_LEN = ARRAY_COUNT(ERR_MSG_2);
     static const char ERR_MSG_3[] = "\"}";
-    static const size_t ERR_MSG_3_LEN = sizeof(ERR_MSG_3) / sizeof(ERR_MSG_3[0]) - 1;
+    static const size_t ERR_MSG_3_LEN = ARRAY_COUNT(ERR_MSG_3);
 
     return QAJ4C_print_callback_constant(ERR_MSG, ERR_MSG_LEN, callback, ptr)
             && QAJ4C_print_callback_uint64(value_ptr->info->err_no, callback, ptr)
@@ -1389,7 +1392,7 @@ bool QAJ4C_std_sprint_function( void *ptr, const char* buffer, size_t size ) {
     QAJ4C_Buffer_printer* printer = (QAJ4C_Buffer_printer*)ptr;
     size_t bytes_left = printer->len - printer->index;
     size_t copy_bytes = (bytes_left > size) ? size : bytes_left;
-    memcpy(printer->buffer + printer->index, buffer, copy_bytes);
+    QAJ4C_MEMCPY(printer->buffer + printer->index, buffer, copy_bytes);
     printer->index += copy_bytes;
     return copy_bytes == size;
 }
@@ -1399,7 +1402,7 @@ bool QAJ4C_std_print_callback_function( void *ptr, const char* buffer, size_t si
     size_t pos = 0;
     QAJ4C_callback_printer* callback_printer = (QAJ4C_callback_printer*)ptr;
     while (result && pos < size) {
-        result = callback_printer->callback(ptr, buffer[pos]);
+        result = callback_printer->callback(callback_printer->external_ptr, buffer[pos]);
         pos += 1;
     }
     return result;

--- a/src/qajson4c/qajson4c_internal.c
+++ b/src/qajson4c/qajson4c_internal.c
@@ -76,7 +76,7 @@ typedef struct QAJ4C_callback_printer {
     QAJ4C_print_callback_fn callback;
 } QAJ4C_callback_printer;
 
-void QAJ4C_std_err_function(void) {
+void QAJ4C_std_err_function( void ) {
     QAJ4C_RAISE(SIGABRT);
 }
 
@@ -95,13 +95,12 @@ static int QAJ4C_first_pass_utf16( QAJ4C_First_pass_parser* parser );
 static void QAJ4C_first_pass_skip_whitespaces_and_comments( QAJ4C_First_pass_parser* parser );
 static void QAJ4C_first_pass_skip_comment( QAJ4C_First_pass_parser* parser );
 
-
 static size_type* QAJ4C_first_pass_fetch_stats_buffer( QAJ4C_First_pass_parser* parser, size_type storage_pos );
 static QAJ4C_Value* QAJ4C_create_error_description( QAJ4C_First_pass_parser* me );
 
 size_t QAJ4C_calculate_max_buffer_parser( QAJ4C_First_pass_parser* parser );
 
-static void QAJ4C_second_pass_parser_init( QAJ4C_Second_pass_parser* me, QAJ4C_First_pass_parser* parser);
+static void QAJ4C_second_pass_parser_init( QAJ4C_Second_pass_parser* me, QAJ4C_First_pass_parser* parser );
 static void QAJ4C_second_pass_process( QAJ4C_Second_pass_parser* me, QAJ4C_Value* result_ptr );
 static void QAJ4C_second_pass_object( QAJ4C_Second_pass_parser* me, QAJ4C_Value* result_ptr );
 static void QAJ4C_second_pass_array( QAJ4C_Second_pass_parser* me, QAJ4C_Value* result_ptr );
@@ -120,8 +119,8 @@ static char QAJ4C_json_message_read( QAJ4C_Json_message* msg );
 static void QAJ4C_json_message_forward( QAJ4C_Json_message* msg );
 static char QAJ4C_json_message_forward_and_peek( QAJ4C_Json_message* msg );
 
-bool QAJ4C_std_sprint_function( void *ptr, const char* buffer, size_t size);
-bool QAJ4C_std_print_callback_function( void *ptr, const char* buffer, size_t size);
+bool QAJ4C_std_sprint_function( void *ptr, const char* buffer, size_t size );
+bool QAJ4C_std_print_callback_function( void *ptr, const char* buffer, size_t size );
 
 static char* QAJ4C_do_print_uint64( uint64_t value, char* buffer, size_t size );
 
@@ -257,7 +256,7 @@ static void QAJ4C_first_pass_parser_set_error( QAJ4C_First_pass_parser* parser, 
     }
 }
 
-static void QAJ4C_first_pass_process( QAJ4C_First_pass_parser* parser, int depth) {
+static void QAJ4C_first_pass_process( QAJ4C_First_pass_parser* parser, int depth ) {
     QAJ4C_first_pass_skip_whitespaces_and_comments(parser);
     parser->amount_nodes++;
     switch (QAJ4C_json_message_peek(parser->msg)) {
@@ -466,7 +465,7 @@ static uint32_t QAJ4C_first_pass_4digits( QAJ4C_First_pass_parser* parser ) {
     return value;
 }
 
-static int QAJ4C_first_pass_utf16( QAJ4C_First_pass_parser* parser) {
+static int QAJ4C_first_pass_utf16( QAJ4C_First_pass_parser* parser ) {
     int amount_utf8_chars = 0;
     uint32_t value = QAJ4C_first_pass_4digits(parser);
 
@@ -1381,7 +1380,7 @@ size_t QAJ4C_sprint_impl( const QAJ4C_Value* value_ptr, char* buffer, size_t buf
     return printer.index;
 }
 
-bool QAJ4C_print_callback_impl( const QAJ4C_Value* value_ptr, QAJ4C_print_callback_fn callback, void* ptr) {
+bool QAJ4C_print_callback_impl( const QAJ4C_Value* value_ptr, QAJ4C_print_callback_fn callback, void* ptr ) {
     QAJ4C_callback_printer printer = {ptr, callback};
     return QAJ4C_print_buffer_callback(value_ptr, QAJ4C_std_print_callback_function, &printer);
 }

--- a/src/qajson4c/qajson4c_internal.c
+++ b/src/qajson4c/qajson4c_internal.c
@@ -71,6 +71,11 @@ typedef struct QAJ4C_Buffer_printer {
     size_type len;
 } QAJ4C_Buffer_printer;
 
+typedef struct QAJ4C_callback_printer {
+    void* external_ptr;
+    QAJ4C_print_callback_fn callback;
+} QAJ4C_callback_printer;
+
 void QAJ4C_std_err_function(void) {
     QAJ4C_RAISE(SIGABRT);
 }
@@ -115,16 +120,18 @@ static char QAJ4C_json_message_read( QAJ4C_Json_message* msg );
 static void QAJ4C_json_message_forward( QAJ4C_Json_message* msg );
 static char QAJ4C_json_message_forward_and_peek( QAJ4C_Json_message* msg );
 
-bool QAJ4C_std_sprint_function( void *ptr, char c);
-bool QAJ4C_print_callback_object( const QAJ4C_Object* value_ptr, QAJ4C_print_callback_fn callback, void *ptr );
-bool QAJ4C_print_callback_array( const QAJ4C_Array* value_ptr, QAJ4C_print_callback_fn callback, void *ptr );
-bool QAJ4C_print_callback_primitive( const QAJ4C_Value* value_ptr, QAJ4C_print_callback_fn callback, void *ptr );
-bool QAJ4C_print_callback_double( double d, QAJ4C_print_callback_fn callback, void *ptr );
-bool QAJ4C_print_callback_uint64( uint64_t value, QAJ4C_print_callback_fn callback, void *ptr );
-bool QAJ4C_print_callback_int64( int64_t value, QAJ4C_print_callback_fn callback, void *ptr );
-bool QAJ4C_print_callback_error( const QAJ4C_Error* value_ptr, QAJ4C_print_callback_fn callback, void *ptr );
-bool QAJ4C_print_callback_constant( const char *string, QAJ4C_print_callback_fn callback, void *ptr );
-bool QAJ4C_print_callback_string( const char *string, QAJ4C_print_callback_fn callback, void *ptr );
+bool QAJ4C_std_sprint_function( void *ptr, const char* buffer, size_t size);
+bool QAJ4C_std_print_callback_function( void *ptr, const char* buffer, size_t size);
+
+bool QAJ4C_print_callback_object( const QAJ4C_Object* value_ptr, QAJ4C_print_buffer_callback_fn callback, void *ptr );
+bool QAJ4C_print_callback_array( const QAJ4C_Array* value_ptr, QAJ4C_print_buffer_callback_fn callback, void *ptr );
+bool QAJ4C_print_callback_primitive( const QAJ4C_Value* value_ptr, QAJ4C_print_buffer_callback_fn callback, void *ptr );
+bool QAJ4C_print_callback_double( double d, QAJ4C_print_buffer_callback_fn callback, void *ptr );
+bool QAJ4C_print_callback_uint64( uint64_t value, QAJ4C_print_buffer_callback_fn callback, void *ptr );
+bool QAJ4C_print_callback_int64( int64_t value, QAJ4C_print_buffer_callback_fn callback, void *ptr );
+bool QAJ4C_print_callback_error( const QAJ4C_Error* value_ptr, QAJ4C_print_buffer_callback_fn callback, void *ptr );
+bool QAJ4C_print_callback_constant( const char *string, size_t size, QAJ4C_print_buffer_callback_fn callback, void *ptr );
+bool QAJ4C_print_callback_string( const char *string, QAJ4C_print_buffer_callback_fn callback, void *ptr );
 
 static const char QAJ4C_NULL_STR[] = "null";
 static const char QAJ4C_TRUE_STR[] = "true";
@@ -1130,7 +1137,7 @@ int QAJ4C_compare_members( const void* lhs, const void* rhs ) {
     return QAJ4C_is_null(&left->key) ? 1 : -1;
 }
 
-bool QAJ4C_print_callback_impl( const QAJ4C_Value* value_ptr, QAJ4C_print_callback_fn callback, void* ptr)
+bool QAJ4C_print_buffer_callback_impl( const QAJ4C_Value* value_ptr, QAJ4C_print_buffer_callback_fn callback, void* ptr)
 {
     bool result = false;
     switch (QAJ4C_get_internal_type(value_ptr)) {
@@ -1145,7 +1152,7 @@ bool QAJ4C_print_callback_impl( const QAJ4C_Value* value_ptr, QAJ4C_print_callba
         result = QAJ4C_print_callback_primitive(value_ptr, callback, ptr);
         break;
     case QAJ4C_NULL:
-        result = QAJ4C_print_callback_constant(QAJ4C_NULL_STR, callback, ptr);
+        result = QAJ4C_print_callback_constant(QAJ4C_NULL_STR, QAJ4C_NULL_STR_LEN, callback, ptr);
         break;
     case QAJ4C_STRING_REF:
     case QAJ4C_INLINE_STRING:
@@ -1161,53 +1168,53 @@ bool QAJ4C_print_callback_impl( const QAJ4C_Value* value_ptr, QAJ4C_print_callba
     return result;
 }
 
-bool QAJ4C_print_callback_object( const QAJ4C_Object* value_ptr, QAJ4C_print_callback_fn callback, void *ptr ) {
+bool QAJ4C_print_callback_object( const QAJ4C_Object* value_ptr, QAJ4C_print_buffer_callback_fn callback, void *ptr ) {
     QAJ4C_Member* top = value_ptr->top;
     size_type i;
     size_type n = ((QAJ4C_Object*)value_ptr)->count;
     bool result = true;
 
-    result = callback(ptr, '{');
+    result = callback(ptr, "{", 1);
     for (i = 0; i < n; ++i) {
         if (!QAJ4C_is_null(&top[i].key)) {
             if (i > 0) {
-                result = result && callback(ptr, ',');
+                result = result && callback(ptr, ",", 1);
             }
 
-            result = result && QAJ4C_print_callback_impl(&top[i].key, callback, ptr)
-                    && callback(ptr, ':')
-                    && QAJ4C_print_callback_impl(&top[i].value, callback, ptr);
+            result = result && QAJ4C_print_buffer_callback(&top[i].key, callback, ptr)
+                    && callback(ptr, ":", 1)
+                    && QAJ4C_print_buffer_callback(&top[i].value, callback, ptr);
         }
     }
-    return result && callback(ptr, '}');
+    return result && callback(ptr, "}", 1);
 }
 
-bool QAJ4C_print_callback_array( const QAJ4C_Array* value_ptr, QAJ4C_print_callback_fn callback, void *ptr )
+bool QAJ4C_print_callback_array( const QAJ4C_Array* value_ptr, QAJ4C_print_buffer_callback_fn callback, void *ptr )
 {
     QAJ4C_Value* top = value_ptr->top;
     bool result = true;
     size_type i;
     size_type n = ((QAJ4C_Array*)value_ptr)->count;
 
-    result = callback(ptr, '[');
+    result = callback(ptr, "[", 1);
     for (i = 0; i < n; ++i) {
         if (i > 0) {
-            result = result && callback(ptr, ',');
+            result = result && callback(ptr, ",", 1);
         }
-        result = result && QAJ4C_print_callback_impl(&top[i], callback, ptr);
+        result = result && QAJ4C_print_buffer_callback(&top[i], callback, ptr);
     }
-    return result && callback(ptr, ']');
+    return result && callback(ptr, "]", 1);
 }
 
-bool QAJ4C_print_callback_primitive( const QAJ4C_Value* value_ptr, QAJ4C_print_callback_fn callback, void *ptr )
+bool QAJ4C_print_callback_primitive( const QAJ4C_Value* value_ptr, QAJ4C_print_buffer_callback_fn callback, void *ptr )
 {
     bool result = true;
     switch (QAJ4C_get_storage_type(value_ptr)) {
     case QAJ4C_PRIMITIVE_BOOL:
         if (((QAJ4C_Primitive*)value_ptr)->data.b) {
-            result = QAJ4C_print_callback_constant( QAJ4C_TRUE_STR, callback, ptr );
+            result = QAJ4C_print_callback_constant( QAJ4C_TRUE_STR, QAJ4C_TRUE_STR_LEN, callback, ptr );
         } else {
-            result = QAJ4C_print_callback_constant( QAJ4C_FALSE_STR, callback, ptr );
+            result = QAJ4C_print_callback_constant( QAJ4C_FALSE_STR, QAJ4C_FALSE_STR_LEN, callback, ptr );
         }
         break;
     case QAJ4C_PRIMITIVE_INT:
@@ -1225,14 +1232,14 @@ bool QAJ4C_print_callback_primitive( const QAJ4C_Value* value_ptr, QAJ4C_print_c
     return result;
 }
 
-bool QAJ4C_print_callback_double( double d, QAJ4C_print_callback_fn callback, void *ptr )
+bool QAJ4C_print_callback_double( double d, QAJ4C_print_buffer_callback_fn callback, void *ptr )
 {
     static int BUFFER_SIZE = 32;
     char buffer[BUFFER_SIZE];
     bool result = true;
 
     if ((d * 0) != 0) {
-        result = QAJ4C_print_callback_constant(QAJ4C_NULL_STR, callback, ptr);
+        result = QAJ4C_print_callback_constant(QAJ4C_NULL_STR, QAJ4C_NULL_STR_LEN, callback, ptr);
     } else {
         double absd = d < 0 ? -d: d;
         double delta = (int64_t)(d) - d;
@@ -1258,94 +1265,121 @@ bool QAJ4C_print_callback_double( double d, QAJ4C_print_callback_fn callback, vo
                     pos += 1;
                 }
                 buffer[pos] = '\0';
+                printf_result = pos;
             }
 
-            result = QAJ4C_print_callback_constant(buffer, callback, ptr);
+            result = callback(ptr, buffer, printf_result);
         }
     }
     return result;
 }
 
-bool QAJ4C_print_callback_uint64( uint64_t value, QAJ4C_print_callback_fn callback, void *ptr )
+bool QAJ4C_print_callback_uint64( uint64_t value, QAJ4C_print_buffer_callback_fn callback, void *ptr )
 {
     static int BUFFER_SIZE = 32;
     char buffer[BUFFER_SIZE];
-    int chars_copied = QAJ4C_UTOSTRN(buffer, BUFFER_SIZE, value) > 0;
-    if (chars_copied > 0 && chars_copied < BUFFER_SIZE) {
-        return QAJ4C_print_callback_constant(buffer, callback, ptr);
+    int chars_copied = QAJ4C_UTOSTRN(buffer, BUFFER_SIZE, value);
+    if ( chars_copied > BUFFER_SIZE ) {
+        return false;
     }
-    return false;
+    return callback(ptr, buffer, chars_copied);
 }
 
-bool QAJ4C_print_callback_int64( int64_t value, QAJ4C_print_callback_fn callback, void *ptr )
+bool QAJ4C_print_callback_int64( int64_t value, QAJ4C_print_buffer_callback_fn callback, void *ptr )
 {
     static int BUFFER_SIZE = 32;
     char buffer[BUFFER_SIZE];
-    int chars_copied = QAJ4C_ITOSTRN(buffer, BUFFER_SIZE, value) > 0;
-    if (chars_copied > 0 && chars_copied < BUFFER_SIZE) {
-        return QAJ4C_print_callback_constant(buffer, callback, ptr);
+    int chars_copied = QAJ4C_ITOSTRN(buffer, BUFFER_SIZE, value);
+    if ( chars_copied > BUFFER_SIZE ) {
+        return false;
     }
-    return false;
+    return callback(ptr, buffer, chars_copied);
 }
 
-bool QAJ4C_print_callback_constant( const char *string, QAJ4C_print_callback_fn callback, void *ptr )
+bool QAJ4C_print_callback_constant( const char *string, size_t size, QAJ4C_print_buffer_callback_fn callback, void *ptr )
 {
-    const char *p = string;
-    bool result = true;
-    for ( ; *p != '\0'; p += 1) {
-        result = result && callback(ptr, *p);
-    }
-    return result;
+    return callback(ptr, string, size);
 }
 
-bool QAJ4C_print_callback_string( const char *string, QAJ4C_print_callback_fn callback, void *ptr )
+bool QAJ4C_print_callback_string( const char *string, QAJ4C_print_buffer_callback_fn callback, void *ptr )
 {
     static const char* replacement_buf[] = {
             "\\u0000", "\\u0001", "\\u0002", "\\u0003", "\\u0004", "\\u0005", "\\u0006", "\\u0007", "\\b",     "\\t",     "\\n",     "\\u000b", "\\f",     "\\r",     "\\u000e", "\\u000f",
-            "\\u0010", "\\u0011", "\\u0012", "\\u0013", "\\u0014", "\\u0015", "\\u0016", "\\u0017", "\\u0018", "\\u0019", "\\u001a", "\\u001b", "\\u001c", "\\u001d", "\\u001e", "\\u001f"
+            "\\u0010", "\\u0011", "\\u0012", "\\u0013", "\\u0014", "\\u0015", "\\u0016", "\\u0017", "\\u0018", "\\u0019", "\\u001a", "\\u001b", "\\u001c", "\\u001d", "\\u001e", "\\u001f",
+            "", "", "\\\"", "", "", "", "", "", "", "", "", "", "\\\\", "", "", "\\/"
     };
-    bool result = true;
     const char *p = string;
+    size_t size = 0;
+    bool result = callback(ptr, "\"", 1);
 
-    result = callback(ptr, '"');
-    for ( ; *p != '\0'; p += 1) {
-        if (QAJ4C_UNLIKELY(*p < 32)) {
-            const char* replacement_string = replacement_buf[(uint8_t)*p];
-            result = result && QAJ4C_print_callback_constant(replacement_string, callback, ptr);
-        } else {
-            if (*p == '"' || *p == '/' || *p == '\\') {
-                result = result && callback(ptr, '\\');
+    while( result && p[size] != '\0' ) {
+        char c = p[size];
+        if (QAJ4C_UNLIKELY(c < 32 || c == '"' || c == '/' || c == '\\')) {
+            if ( c >= 32 ) {
+                /* set the char in the 2x range so we can use the replacement buffer to replace the string. */
+                c = (c & 0xF) | 0x20;
             }
-            result = result && callback(ptr, *p);
+            const char* replacement_string = replacement_buf[(uint8_t)c];
+            result = result && callback(ptr, p, size); /* flush the string until now */
+            result = result && callback(ptr, replacement_string, strlen(replacement_string));
+            p = p + size + 1;
+            size = 0;
+        } else {
+            size += 1;
         }
     }
-    return result && callback(ptr, '"');
+
+    if (size > 0) {
+        result = result && callback(ptr, p, size);
+    }
+
+    return result && callback(ptr, "\"", 1);
 }
 
-bool QAJ4C_print_callback_error( const QAJ4C_Error* value_ptr, QAJ4C_print_callback_fn callback, void *ptr )
+bool QAJ4C_print_callback_error( const QAJ4C_Error* value_ptr, QAJ4C_print_buffer_callback_fn callback, void *ptr )
 {
-    return QAJ4C_print_callback_constant("{\"error\":\"Unable to parse json message. Error (", callback, ptr)
+    static const char ERR_MSG[] = "{\"error\":\"Unable to parse json message. Error (";
+    static const size_t ERR_MSG_LEN = sizeof(ERR_MSG) / sizeof(ERR_MSG[0]) - 1;
+    static const char ERR_MSG_2[] = ") at position ";
+    static const size_t ERR_MSG_2_LEN = sizeof(ERR_MSG_2) / sizeof(ERR_MSG_2[0]) - 1;
+    static const char ERR_MSG_3[] = "\"}";
+    static const size_t ERR_MSG_3_LEN = sizeof(ERR_MSG_3) / sizeof(ERR_MSG_3[0]) - 1;
+
+    return QAJ4C_print_callback_constant(ERR_MSG, ERR_MSG_LEN, callback, ptr)
             && QAJ4C_print_callback_uint64(value_ptr->info->err_no, callback, ptr)
-            && QAJ4C_print_callback_constant(") at position ", callback, ptr)
+            && QAJ4C_print_callback_constant(ERR_MSG_2, ERR_MSG_2_LEN, callback, ptr)
             && QAJ4C_print_callback_uint64(value_ptr->info->json_pos, callback, ptr)
-            && QAJ4C_print_callback_constant("\"}", callback, ptr);
+            && QAJ4C_print_callback_constant(ERR_MSG_3, ERR_MSG_3_LEN, callback, ptr);
 }
 
 
 size_t QAJ4C_sprint_impl( const QAJ4C_Value* value_ptr, char* buffer, size_t buffer_size, size_t index ) {
     QAJ4C_Buffer_printer printer = {buffer, index, buffer_size};
-    QAJ4C_print_callback( value_ptr, QAJ4C_std_sprint_function, &printer );
+    QAJ4C_print_buffer_callback( value_ptr, QAJ4C_std_sprint_function, &printer );
     return printer.index;
 }
 
-bool QAJ4C_std_sprint_function( void *ptr, char c ) {
-    bool result = false;
+bool QAJ4C_print_callback_impl( const QAJ4C_Value* value_ptr, QAJ4C_print_callback_fn callback, void* ptr) {
+    QAJ4C_callback_printer printer = {ptr, callback};
+    return QAJ4C_print_buffer_callback(value_ptr, QAJ4C_std_print_callback_function, &printer);
+}
+
+bool QAJ4C_std_sprint_function( void *ptr, const char* buffer, size_t size ) {
     QAJ4C_Buffer_printer* printer = (QAJ4C_Buffer_printer*)ptr;
-    if ( printer->index < printer->len )
-    {
-        printer->buffer[printer->index] = c;
-        printer->index += 1;
-        result = true;
+    size_t bytes_left = printer->len - printer->index;
+    size_t copy_bytes = (bytes_left > size) ? size : bytes_left;
+    memcpy(printer->buffer + printer->index, buffer, copy_bytes);
+    printer->index += copy_bytes;
+    return copy_bytes == size;
+}
+
+bool QAJ4C_std_print_callback_function( void *ptr, const char* buffer, size_t size ) {
+    bool result = true;
+    size_t pos = 0;
+    QAJ4C_callback_printer* callback_printer = (QAJ4C_callback_printer*)ptr;
+    while (result && pos < size) {
+        result = callback_printer->callback(ptr, buffer[pos]);
+        pos += 1;
     }
     return result;
 }

--- a/src/qajson4c/qajson4c_internal.h
+++ b/src/qajson4c/qajson4c_internal.h
@@ -162,7 +162,7 @@ struct QAJ4C_Member {
 extern QAJ4C_fatal_error_fn g_qaj4c_err_function;
 
 void QAJ4C_std_err_function( void );
-size_t QAJ4C_parse_generic(QAJ4C_Builder* builder, const char* json, size_t json_len, int opts, const QAJ4C_Value** result_ptr, QAJ4C_realloc_fn realloc_callback);
+size_t QAJ4C_parse_generic( QAJ4C_Builder* builder, const char* json, size_t json_len, int opts, const QAJ4C_Value** result_ptr, QAJ4C_realloc_fn realloc_callback );
 size_t QAJ4C_calculate_max_buffer_generic( const char* json, size_t json_len, int opts );
 
 QAJ4C_Value* QAJ4C_builder_pop_values( QAJ4C_Builder* builder, size_type count );
@@ -173,17 +173,15 @@ uint8_t QAJ4C_get_storage_type( const QAJ4C_Value* value_ptr );
 uint8_t QAJ4C_get_compatibility_types( const QAJ4C_Value* value_ptr );
 QAJ4C_INTERNAL_TYPE QAJ4C_get_internal_type( const QAJ4C_Value* value_ptr );
 
-
 const QAJ4C_Value* QAJ4C_object_get_unsorted( QAJ4C_Object* obj_ptr, QAJ4C_Value* str_ptr );
 const QAJ4C_Value* QAJ4C_object_get_sorted( QAJ4C_Object* obj_ptr, QAJ4C_Value* str_ptr );
-
 
 int QAJ4C_strcmp( const QAJ4C_Value* lhs, const QAJ4C_Value* rhs );
 int QAJ4C_compare_members( const void* lhs, const void * rhs );
 
 size_t QAJ4C_sprint_impl( const QAJ4C_Value* value_ptr, char* buffer, size_t buffer_size, size_t index );
-bool QAJ4C_print_buffer_callback_impl( const QAJ4C_Value* value_ptr, QAJ4C_print_buffer_callback_fn callback, void* ptr);
-bool QAJ4C_print_callback_impl( const QAJ4C_Value* value_ptr, QAJ4C_print_callback_fn callback, void* ptr);
+bool QAJ4C_print_buffer_callback_impl( const QAJ4C_Value* value_ptr, QAJ4C_print_buffer_callback_fn callback, void* ptr );
+bool QAJ4C_print_callback_impl( const QAJ4C_Value* value_ptr, QAJ4C_print_callback_fn callback, void* ptr );
 
 #ifdef __cplusplus
 }

--- a/src/qajson4c/qajson4c_internal.h
+++ b/src/qajson4c/qajson4c_internal.h
@@ -182,6 +182,7 @@ int QAJ4C_strcmp( const QAJ4C_Value* lhs, const QAJ4C_Value* rhs );
 int QAJ4C_compare_members( const void* lhs, const void * rhs );
 
 size_t QAJ4C_sprint_impl( const QAJ4C_Value* value_ptr, char* buffer, size_t buffer_size, size_t index );
+bool QAJ4C_print_buffer_callback_impl( const QAJ4C_Value* value_ptr, QAJ4C_print_buffer_callback_fn callback, void* ptr);
 bool QAJ4C_print_callback_impl( const QAJ4C_Value* value_ptr, QAJ4C_print_callback_fn callback, void* ptr);
 
 #ifdef __cplusplus

--- a/src/qajson4c/qajson_stdwrap.h
+++ b/src/qajson4c/qajson_stdwrap.h
@@ -88,8 +88,6 @@
 #error "Invalid word size detected!"
 #endif
 
-#define QAJ4C_ITOSTRN(buffer, n, value) QAJ4C_SNPRINTF(buffer, n, "%" PRIi64, value)
-#define QAJ4C_UTOSTRN(buffer, n, value) QAJ4C_SNPRINTF(buffer, n, "%" PRIu64, value)
 #define QAJ4C_STRTOD strtod
 #define QAJ4C_QSORT qsort
 #define QAJ4C_BSEARCH bsearch


### PR DESCRIPTION
- Created a QAJ4C_Object_builder for a more efficient Object creation.
- Added a printer callback to write a char-buffer with a given length as an addition to the current call callback per individual character.
- Improved performance printing integer values to string.
- minor code style changes.